### PR TITLE
fix the make error bug when build without rocksdb default

### DIFF
--- a/vector/rocksdb_wrapper.h
+++ b/vector/rocksdb_wrapper.h
@@ -1,3 +1,14 @@
+/**
+ * Copyright 2019 The Gamma Authors.
+ *
+ * This source code is licensed under the Apache License, Version 2.0 license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef WITH_ROCKSDB
+
+#pragma once
+
 #include <string>
 #include "rocksdb/db.h"
 #include "rocksdb/options.h"
@@ -17,3 +28,5 @@ struct RocksDBWrapper {
 };
 
 }  // namespace tig_gamma
+
+#endif  // WITH_ROCKSDB


### PR DESCRIPTION
修复默认没有Rocksdb下的编译错误~
rocksdb_wrapper.h文件应该参考table.h和rocksdb_raw_vector.h一样，使用WITH_ROCKSDB