### PR TITLE
delete duplicate includeing and namespace using, reorder the include file

### DIFF
--- a/vector/memory_raw_vector.cc
+++ b/vector/memory_raw_vector.cc
@@ -5,19 +5,14 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-#include "memory_raw_vector.h"
-
 #include <unistd.h>
 
+#include "memory_raw_vector.h"
 #include "error_code.h"
 
 using std::string;
 using namespace rocksdb;
 
-#include "error_code.h"
-
-using std::string;
-using namespace rocksdb;
 namespace tig_gamma {
 
 MemoryRawVector::MemoryRawVector(VectorMetaInfo *meta_info,


### PR DESCRIPTION
1、删除重复的#include和using
2、针对#include顺序排序，系统引入在前，其他在后