### PR TITLE
Update gamma_index_ivfpq.cc

### DIFF
--- a/index/impl/gamma_index_ivfpq.cc
+++ b/index/impl/gamma_index_ivfpq.cc
@@ -666,7 +666,9 @@ bool GammaIVFPQIndex::Add(int n, const uint8_t *vec) {
     assert(key < (long)nlist);
     if (key < 0) {
       n_ignore++;
-      continue;
+      LOG(WARNING) << "ivfpq add invalid key=" << key
+                   << ", vid=" << vid;
+      key = vid % nlist;   
     }
 
     // long id = (long)(indexed_vec_count_++);


### PR DESCRIPTION
Infinity float 导致vid和docid无法匹配，影响召回。
当key为-1时，随机一个key值。