### PR TITLE
fix segment fault crash when building index if using BINARYIVF

### DIFF
--- a/vector/vector_manager.cc
+++ b/vector/vector_manager.cc
@@ -294,16 +294,16 @@ int VectorManager::AddRTVecsToIndex() {
         } else {
           int raw_d = raw_vec->MetaInfo()->Dimension();
           if (raw_vec->MetaInfo()->DataType() == VectorValueType::BINARY) {
-            raw_d /= 8;
             add_vec = new uint8_t[raw_d * count_per_index];
           } else {
             add_vec = new uint8_t[raw_d * count_per_index * sizeof(float)];
           }
           del_vec.set(add_vec);
           size_t offset = 0;
+          size_t element_size = raw_vec->MetaInfo()->DataType() == VectorValueType::BINARY ? sizeof(char) : sizeof(float);
           for (size_t i = 0; i < vector_head.Size(); ++i) {
             memcpy((void *)(add_vec + offset), (void *)vector_head.Get(i),
-                   sizeof(float) * raw_d * lens[i]);
+                   element_size * raw_d * lens[i]);
 
             if (raw_vec->MetaInfo()->DataType() == VectorValueType::BINARY) {
               offset += raw_d * lens[i];


### PR DESCRIPTION
当使用BINARYIVF检索模型，在构建实时索引过程中，内存拷贝导致段错误，gamma崩溃