### PR TITLE
fix segment fault when indexing BINARYIVF

### DIFF
--- a/index/impl/gamma_index_binary_ivf.cc
+++ b/index/impl/gamma_index_binary_ivf.cc
@@ -223,13 +223,13 @@ int GammaIndexBinaryIVF::Indexing() {
   if (lens.size() == 1) {
     train_vec = headers.Get(0);
   } else {
-    int raw_d = d;
+    int raw_d = raw_vec->MetaInfo()->Dimension();
     train_vec = new uint8_t[raw_d * num];
     del_vec.set(train_vec);
     size_t offset = 0;
     for (size_t i = 0; i < headers.Size(); ++i) {
       memcpy((void *)(train_vec + offset), (void *)headers.Get(i),
-             sizeof(float) * raw_d * lens[i]);
+             sizeof(char) * raw_d * lens[i]);
       offset += raw_d * lens[i];
     }
   }

--- a/vector/vector_manager.cc
+++ b/vector/vector_manager.cc
@@ -294,16 +294,16 @@ int VectorManager::AddRTVecsToIndex() {
         } else {
           int raw_d = raw_vec->MetaInfo()->Dimension();
           if (raw_vec->MetaInfo()->DataType() == VectorValueType::BINARY) {
-            raw_d /= 8;
             add_vec = new uint8_t[raw_d * count_per_index];
           } else {
             add_vec = new uint8_t[raw_d * count_per_index * sizeof(float)];
           }
           del_vec.set(add_vec);
           size_t offset = 0;
+          size_t element_size = raw_vec->MetaInfo()->DataType() == VectorValueType::BINARY ? sizeof(char) : sizeof(float);
           for (size_t i = 0; i < vector_head.Size(); ++i) {
             memcpy((void *)(add_vec + offset), (void *)vector_head.Get(i),
-                   sizeof(float) * raw_d * lens[i]);
+                   element_size * raw_d * lens[i]);
 
             if (raw_vec->MetaInfo()->DataType() == VectorValueType::BINARY) {
               offset += raw_d * lens[i];


### PR DESCRIPTION
如果存储类型是Mmap并且使用BINARYIVF检索模型，在索引训练、构建过程中，内存拷贝出错导致段错误，索引后台线程或gamma引擎崩溃