### PR TITLE
index building should be always waiting rather than return error which causing crash

### DIFF
--- a/storage/segment.cc
+++ b/storage/segment.cc
@@ -340,9 +340,10 @@ int Segment::GetValues(uint8_t *value, int id, int n) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     ++count;
     if (count > 10) {
-      LOG(ERROR) << "Because the wait timeout, segment[" << seg_id_
-                 << "] GetValue(" << id << ") failed.";
-      return -1;
+      LOG(WARNING) << "Waited " << count * 10
+                << "ms because the data is not being brushed to disk."
+                << " segment[" << seg_id_
+                << "], GetValue(" << id << ", " << n << ")";
     }
   }
   blocks_->Read(value, n_bytes, start);

--- a/storage/storage_manager.cc
+++ b/storage/storage_manager.cc
@@ -268,13 +268,11 @@ int StorageManager::Get(long id, const uint8_t *&value) {
   int count = 0;
   while (seg_id >= segments_.size()) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    LOG(INFO) << "Get(),seg_id:" << seg_id
-              << " >= segments_.size():" << segments_.size();
     ++count;
     if (count > 10) {
-      LOG(ERROR) << "Because the wait timeout, StorageManager["
-                 << cache_->GetName() << "] Get(" << id << ") failed.";
-      return -1;
+      LOG(WARNING) << "Waited " << count * 10
+                   << "ms. Get(), seg_id: " << seg_id
+                   << " >= segments_.size(): " << segments_.size();
     }
   }
   Segment *segment = segments_[seg_id];


### PR DESCRIPTION
在写压力比较大的情况下，会出现等待100ms仍然没有刷到磁盘，此时返回错误码-1，但是上层调用代码并没有处理该错误，这样会导致非法内存访问进而引擎崩溃。改为数据还没有刷到磁盘时，索引构建应该一直等待。