### PR TITLE
set binaryivf initial bucket size properly

### DIFF
--- a/index/impl/gamma_index_binary_ivf.cc
+++ b/index/impl/gamma_index_binary_ivf.cc
@@ -98,8 +98,9 @@ int GammaIndexBinaryIVF::Init(const std::string &model_parameters, int indexing_
   code_size = d / 8;
   verbose = false;
 
+  int bucket_keys = std::max(1000, this->indexing_size_ / binary_param.ncentroids);
   rt_invert_index_ptr_ = new realtime::RTInvertIndex(
-      this->nlist, this->code_size, raw_vec->VidMgr(), raw_vec->Bitmap(), 10000,
+      this->nlist, this->code_size, raw_vec->VidMgr(), raw_vec->Bitmap(), bucket_keys,
       1280000);
   // default is true in faiss
   is_trained = false;


### PR DESCRIPTION
For binaryivf index, the initial bucket size is 10000 which is very high for small tables that have no more than 10 million docs. Setting  the initial bucket size properly can reduce memory usage for small tables.